### PR TITLE
Aiocallback 1.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Virtual enviornments including uv
+.venv
+# Obviously
+__pycache__
+*.egg-info
+

--- a/aiocallback/__init__.py
+++ b/aiocallback/__init__.py
@@ -6,7 +6,6 @@ from .events import (
     SelfEventWrapper,
     contextevent,
     event,
-    subclasscontextevent,
     subcontextevent,
     subclassevent,
 )
@@ -14,3 +13,16 @@ from .events import (
 __author__ = "Vizonex"
 
 from .__version__ import __version__
+
+__all__ = (
+    "EventList",
+    "EventListMetaclass",
+    "EventWrapper",
+    "SelfEventWrapper",
+    "contextevent",
+    "event",
+    "subcontextevent",
+    "subclassevent",
+    "__version__",
+    "__author__"
+)

--- a/aiocallback/__init__.py
+++ b/aiocallback/__init__.py
@@ -24,5 +24,5 @@ __all__ = (
     "subcontextevent",
     "subclassevent",
     "__version__",
-    "__author__"
+    "__author__",
 )

--- a/aiocallback/events.py
+++ b/aiocallback/events.py
@@ -7,7 +7,6 @@ from functools import partial
 from typing import (
     Any,
     Callable,
-    ClassVar,
     Coroutine,
     Generic,
     Iterable,
@@ -16,9 +15,8 @@ from typing import (
     TypeVar,
 )
 
-from deprecated_params import deprecated_params
 from frozenlist import FrozenList
-from propcache import cached_property
+from propcache import under_cached_property
 
 if sys.version_info >= (3, 10):
     from typing import Concatenate, ParamSpec
@@ -31,13 +29,27 @@ OwnerT = TypeVar("OwnerT")
 
 AsyncFunction = Callable[P, Coroutine[Any, Any, T]]
 
+__all__ = (
+    "EventList",
+    "EventListMetaclass",
+    "EventWrapper",
+    "SelfEventWrapper",
+    "contextevent",
+    "event",
+    "subcontextevent",
+    "subclassevent",
+)
 
-# EventWrapper is on par with aiosignal instead of being it's subclass
-# This saves a couple of steps for many of our subclasses...
-
+# EventWrapper is inspired by aiosignal but has a few internal 
+# changes made to make it more beginner-friendly.
 
 class EventWrapper(FrozenList[AsyncFunction[P, T]]):
-    """A wrapper class for making a callback function that carries a few more methods than aiosignal has."""
+    """A wrapper class for making a callback function that carries 
+    a few more methods than aiosignal has. What makes EventWrapper 
+    different from aiosignal is that it utilizes ParamSpec. This can 
+    have an advantage when you need to typehint multiple different 
+    functions, positonal and keyword arguments.
+    """
 
     __slots__ = ("_owner",)
 
@@ -47,11 +59,19 @@ class EventWrapper(FrozenList[AsyncFunction[P, T]]):
         /,
         owner=None,
     ):
+        """
+        Parameters
+        ----------
+
+        :param owner: Simillar to `aiosignal.Signal` using an owner is entirely optional but encouraged
+ 
+        """
         super().__init__(items)
         self._owner = owner
 
     def __call__(self, func: AsyncFunction[P, T]):
-        """appends a callback function to the event, returns the same function for futher use elsewhere...
+        """
+        appends a callback function to the event, returns the same function for futher use elsewhere...
         this is equivilent to calling the `append()` method::
 
             from aiocallback import EventWrapper
@@ -60,7 +80,12 @@ class EventWrapper(FrozenList[AsyncFunction[P, T]]):
             @custom_event
             async def on_event():
                 ...
-
+        
+        Parameters
+        ----------
+        
+        :param func: the function that should get called back to when the event is invoked
+        
         """
         self.append(func)
         return func
@@ -68,6 +93,9 @@ class EventWrapper(FrozenList[AsyncFunction[P, T]]):
     # Typehint our signal so that pyright can see
     # the arguments that need to be passed
     async def send(self, *args: P.args, **kw: P.kwargs) -> None:
+        """
+        Sends Parameters to invoke all functions tied to this event.
+        """
         if not self.frozen:
             raise RuntimeError("Cannot send non-frozen events.")
 
@@ -90,42 +118,42 @@ class SelfEventWrapper(EventWrapper[P, T]):
         return await super().send(self._owner, *args, **kwargs)  # type: ignore
 
 
-@deprecated_params(
-    ["abstract"],
-    "abstract keyword is deprecated & it's functionality has been removed, removal of warning planned in 0.1.7",
-)
 class event(Generic[OwnerT, P, T]):
     """A Couroutine Based implementation of an asynchronous callback object. 
     This object is a replacement for aiosignal. with easier configuration options...
-    
-    abstract: `bool` inner function upon being called is considered abstract... \
-        if `true` inner custom function will not be called with the `send()` method and it \
-        will be considered as nothing but typehinting.
     """
 
-    __slots__ = ("func", "name", "_wrapper")
-
+    __slots__ = ("_func", "_name", "_wrapper", "_cache")
     _wrapper: EventWrapper[P, T]
 
     def __init__(self, func: AsyncFunction[Concatenate[OwnerT, P], T], **kw) -> None:
-        self.func = func
-        self.name = func.__name__
+        self._func = func
+        self._name = func.__name__
+        self._cache = {}
 
         if hasattr(func, "__isabstractmethod__"):
             warnings.warn(
-                "using an abc.abstractmethod wrapper with an event is discouraged",
+                "using an abc.abstractmethod wrapper with an event is discouraged" \
+                "this will throw an error in a future version of aiocallback!",
                 UserWarning,
                 2,
             )
 
-    # __doc__ couldn't be made into a slot
+    # XXX: __doc__ couldn't be made into a slot
     # so we had to come up with an alternative method
-    @cached_property
+    @under_cached_property
     def __doc__(self):
-        return self.func.__doc__
+        return self._func.__doc__
 
     def __wrapper_init__(self, owner: OwnerT):
-        """A Special dunder method for initalizing an Event Wrapper"""
+        """
+        A Special dunder method for initalizing an Event Wrapper
+
+        Parameters
+        ----------
+
+        :param owner: the owning class object that will maintain the events called
+        """
         self._wrapper = EventWrapper(owner=owner)
         return self._wrapper
 
@@ -135,11 +163,11 @@ class event(Generic[OwnerT, P, T]):
     # will always attempt to be inbounds...
     def __set_name__(self, owner: OwnerT, name: str):
         self.__wrapper_init__(owner)
-        self.name = name
+        self._name = name
 
     # inner _event_cache is removed because using slots on the descriptor is faster
 
-    def __get__(self, inst: OwnerT, owner) -> EventWrapper[P, T]:
+    def __get__(self, inst: OwnerT, owner: type[OwnerT]) -> EventWrapper[P, T]:
         # if for some reason we did not obtain this during __new__...
         if not hasattr(self, "_wrapper"):
             self.__wrapper_init__(owner)
@@ -151,11 +179,11 @@ class event(Generic[OwnerT, P, T]):
 class subclassevent(event[OwnerT, P, T]):
     """Passes the context class to the member descriptor"""
 
-    def __wrapper_init__(self, owner: OwnerT):
-        self._wrapper = EventWrapper((partial(self.func, owner),), owner)
+    def __wrapper_init__(self, owner: OwnerT) -> EventWrapper[P, T]:
+        self._wrapper = EventWrapper((partial(self._func, owner),), owner)
         return self._wrapper
 
-    def __get__(self, inst: OwnerT, owner) -> EventWrapper[P, T]:
+    def __get__(self, inst: OwnerT, owner: type[OwnerT] | None) -> EventWrapper[P, T]:
         # Incase the user's object does not have a base property to use...
         if not hasattr(self, "_wrapper") or self._wrapper._owner != inst:
             # Call the instance instead so that the instance is called with the event
@@ -172,32 +200,21 @@ class contextevent(event[OwnerT, P, T]):
         self._wrapper = SelfEventWrapper(owner=owner)
         return self._wrapper
 
-    def __get__(self, inst: OwnerT, owner) -> SelfEventWrapper[P, T]:
+    def __get__(self, inst: OwnerT, owner: type[OwnerT] | None) -> SelfEventWrapper[P, T]:
         # Incase the user's object does not have a base property to use...
         if not hasattr(self, "_wrapper") or self._wrapper._owner != inst:
             self.__wrapper_init__(inst)
         return self._wrapper
 
 
-class subcontextevent(contextevent):
+class subcontextevent(contextevent[OwnerT, P, T]):
     """sends the class holding the event as an instance through all the callbacks made including the inner wrapper
     being utilized."""
 
-    def __wrapper_init__(self, owner):
-        self._wrapper = SelfEventWrapper((self.func,), owner)
+    def __wrapper_init__(self, owner: OwnerT) -> SelfEventWrapper:
+        self._wrapper = SelfEventWrapper((self._func,), owner)
         return self._wrapper
 
-
-class subclasscontextevent(subcontextevent):
-    def __init__(self, func, **kw):
-        warnings.warn(
-            "subclasscontextevent event has been"
-            " renamed to subcontextevent (to try and lessen confusion),"
-            " subclasscontextevent will be removed in 0.1.7",
-            DeprecationWarning,
-            2,
-        )
-        super().__init__(func, **kw)
 
 
 # Inspired by PEP 3115's example
@@ -207,7 +224,7 @@ class event_table(dict):
     def __init__(self):
         self["_events"] = {}
 
-    def __setitem__(self, key: str, value):
+    def __setitem__(self, key: str, value:Any):
         # if the key is not already defined, add it to the
         # list of keys.
         if key not in self:
@@ -224,10 +241,13 @@ class event_table(dict):
 
 
 class EventListMetaclass(type):
-    """A Freezeable Metaclass for getting rid of
-    the need of freezing different member descriptors"""
+    """A Freezeable Metaclass for freezing wrapped events in a class object"""
 
     _events: dict[str, event]
+    
+    # EventLists fully support popcache's under_cached_property 
+    # if user wants to use it to make immutable properties
+    _cache: dict[str, Any]
 
     @classmethod
     def __prepare__(
@@ -237,6 +257,7 @@ class EventListMetaclass(type):
         for b in bases:
             if isinstance(b, EventListMetaclass):
                 classdict["_events"].update(b._events)
+        classdict["_cache"] = {}
         return classdict
 
     def __new__(cls, name: str, bases: tuple[type, ...], classdict: dict, /, **kw):
@@ -247,14 +268,14 @@ class EventList(metaclass=EventListMetaclass):
     """A Subclassable Helper for freezing up multiple callbacks together
     without needing to handle it all yourself"""
 
-    _events: ClassVar[dict[str, event]]
 
-    @cached_property
+    @under_cached_property
     def events(self) -> frozenset[str]:
         """An immutable set of event names attached to this class object"""
         return frozenset(self._events.keys())
 
-    def freeze(self):
+    # TODO: Should Freeze be single-dispatch in the future?
+    def freeze(self) -> None:
         """Freezes up all the different callback events
         that were configured"""
         for e in self._events.keys():

--- a/aiocallback/events.py
+++ b/aiocallback/events.py
@@ -58,13 +58,14 @@ class EventWrapper(FrozenList[AsyncFunction[P, T]]):
         self,
         items: List[AsyncFunction[P, T]] | Iterable[AsyncFunction[P, T]] | None = None,
         /,
-        owner=None,
+        owner: Any | None = None,
     ):
         """
         Parameters
         ----------
 
         :param owner: Simillar to `aiosignal.Signal` using an owner is entirely optional but encouraged
+        :param items: A list or sequence of funtions to utilize.
 
         """
         super().__init__(items)
@@ -256,9 +257,11 @@ class EventListMetaclass(type):
         cls, name: str, bases: tuple[type, ...], /, **kw
     ) -> MutableMapping[str, object]:
         classdict = event_table()
+    
         for b in bases:
             if isinstance(b, EventListMetaclass):
                 classdict["_events"].update(b._events)
+    
         classdict["_cache"] = {}
         return classdict
 

--- a/aiocallback/events.py
+++ b/aiocallback/events.py
@@ -40,14 +40,15 @@ __all__ = (
     "subclassevent",
 )
 
-# EventWrapper is inspired by aiosignal but has a few internal 
+# EventWrapper is inspired by aiosignal but has a few internal
 # changes made to make it more beginner-friendly.
 
+
 class EventWrapper(FrozenList[AsyncFunction[P, T]]):
-    """A wrapper class for making a callback function that carries 
-    a few more methods than aiosignal has. What makes EventWrapper 
-    different from aiosignal is that it utilizes ParamSpec. This can 
-    have an advantage when you need to typehint multiple different 
+    """A wrapper class for making a callback function that carries
+    a few more methods than aiosignal has. What makes EventWrapper
+    different from aiosignal is that it utilizes ParamSpec. This can
+    have an advantage when you need to typehint multiple different
     functions, positonal and keyword arguments.
     """
 
@@ -64,7 +65,7 @@ class EventWrapper(FrozenList[AsyncFunction[P, T]]):
         ----------
 
         :param owner: Simillar to `aiosignal.Signal` using an owner is entirely optional but encouraged
- 
+
         """
         super().__init__(items)
         self._owner = owner
@@ -80,12 +81,12 @@ class EventWrapper(FrozenList[AsyncFunction[P, T]]):
             @custom_event
             async def on_event():
                 ...
-        
+
         Parameters
         ----------
-        
+
         :param func: the function that should get called back to when the event is invoked
-        
+
         """
         self.append(func)
         return func
@@ -119,7 +120,7 @@ class SelfEventWrapper(EventWrapper[P, T]):
 
 
 class event(Generic[OwnerT, P, T]):
-    """A Couroutine Based implementation of an asynchronous callback object. 
+    """A Couroutine Based implementation of an asynchronous callback object.
     This object is a replacement for aiosignal. with easier configuration options...
     """
 
@@ -129,11 +130,11 @@ class event(Generic[OwnerT, P, T]):
     def __init__(self, func: AsyncFunction[Concatenate[OwnerT, P], T], **kw) -> None:
         self._func = func
         self._name = func.__name__
-        self._cache = {}
+        self._cache: dict[str, Any] = {}
 
         if hasattr(func, "__isabstractmethod__"):
             warnings.warn(
-                "using an abc.abstractmethod wrapper with an event is discouraged" \
+                "using an abc.abstractmethod wrapper with an event is discouraged"
                 "this will throw an error in a future version of aiocallback!",
                 UserWarning,
                 2,
@@ -167,7 +168,7 @@ class event(Generic[OwnerT, P, T]):
 
     # inner _event_cache is removed because using slots on the descriptor is faster
 
-    def __get__(self, inst: OwnerT, owner: type[OwnerT]) -> EventWrapper[P, T]:
+    def __get__(self, inst: OwnerT, owner: OwnerT) -> EventWrapper[P, T]:
         # if for some reason we did not obtain this during __new__...
         if not hasattr(self, "_wrapper"):
             self.__wrapper_init__(owner)
@@ -183,7 +184,7 @@ class subclassevent(event[OwnerT, P, T]):
         self._wrapper = EventWrapper((partial(self._func, owner),), owner)
         return self._wrapper
 
-    def __get__(self, inst: OwnerT, owner: type[OwnerT] | None) -> EventWrapper[P, T]:
+    def __get__(self, inst: OwnerT, owner: Any) -> EventWrapper[P, T]:
         # Incase the user's object does not have a base property to use...
         if not hasattr(self, "_wrapper") or self._wrapper._owner != inst:
             # Call the instance instead so that the instance is called with the event
@@ -200,7 +201,9 @@ class contextevent(event[OwnerT, P, T]):
         self._wrapper = SelfEventWrapper(owner=owner)
         return self._wrapper
 
-    def __get__(self, inst: OwnerT, owner: type[OwnerT] | None) -> SelfEventWrapper[P, T]:
+    def __get__(
+        self, inst: OwnerT, owner: Any
+    ) -> SelfEventWrapper[P, T]:
         # Incase the user's object does not have a base property to use...
         if not hasattr(self, "_wrapper") or self._wrapper._owner != inst:
             self.__wrapper_init__(inst)
@@ -216,7 +219,6 @@ class subcontextevent(contextevent[OwnerT, P, T]):
         return self._wrapper
 
 
-
 # Inspired by PEP 3115's example
 class event_table(dict):
     __slots__ = ("events",)
@@ -224,7 +226,7 @@ class event_table(dict):
     def __init__(self):
         self["_events"] = {}
 
-    def __setitem__(self, key: str, value:Any):
+    def __setitem__(self, key: str, value: Any):
         # if the key is not already defined, add it to the
         # list of keys.
         if key not in self:
@@ -244,8 +246,8 @@ class EventListMetaclass(type):
     """A Freezeable Metaclass for freezing wrapped events in a class object"""
 
     _events: dict[str, event]
-    
-    # EventLists fully support popcache's under_cached_property 
+
+    # EventLists fully support popcache's under_cached_property
     # if user wants to use it to make immutable properties
     _cache: dict[str, Any]
 
@@ -267,6 +269,8 @@ class EventListMetaclass(type):
 class EventList(metaclass=EventListMetaclass):
     """A Subclassable Helper for freezing up multiple callbacks together
     without needing to handle it all yourself"""
+    _events: dict[str, Any]
+    _cache: dict[str, Any]
 
 
     @under_cached_property

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,7 +1,6 @@
 attrs
 frozenlist
 typing_extensions
-deprecated-params
 pytest
 pytest-asyncio
 winloop; platform_system == "Windows"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,8 @@
 import asyncio
-import sys
 import platform
+import sys
+
 import pytest
-import pytest_asyncio
 
 uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
 
@@ -13,6 +13,7 @@ if platform.python_implementation() != "PyPy":
 
     if sys.version_info >= (3, 14):
         import warnings
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", DeprecationWarning)
             from asyncio import DefaultEventLoopPolicy
@@ -25,7 +26,9 @@ if platform.python_implementation() != "PyPy":
             DefaultEventLoopPolicy(),
             uvloop.EventLoopPolicy(),
         ),
-        ids=str
+        ids=str,
     )
-    def event_loop_policy(request:pytest.FixtureRequest) -> asyncio.AbstractEventLoopPolicy:
+    def event_loop_policy(
+        request: pytest.FixtureRequest,
+    ) -> asyncio.AbstractEventLoopPolicy:
         return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,6 @@ import sys
 
 import pytest
 
-uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
 
 
 # XXX: PyPy has problems right now so it's also ignored.
@@ -14,6 +13,8 @@ if platform.python_implementation() != "PyPy":
     if sys.version_info <= (3, 14):
         from asyncio import DefaultEventLoopPolicy
 
+        uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
+        
         @pytest.fixture(
             scope="session",
             params=(
@@ -26,4 +27,3 @@ if platform.python_implementation() != "PyPy":
             request: pytest.FixtureRequest,
         ) -> asyncio.AbstractEventLoopPolicy:
             return request.param
-    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,24 +4,28 @@ import platform
 import pytest
 import pytest_asyncio
 
+uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
+
 
 # XXX: PyPy has problems right now so it's also ignored.
 if platform.python_implementation() != "PyPy":
-    @pytest.fixture(scope="module")
-    def event_loop():
-        if sys.platform != "win32":
-            try:
-                import uvloop  # type:ignore
-                return uvloop.new_event_loop()
-            except ModuleNotFoundError: 
-                # fallback
-                return asyncio.new_event_loop()
-        else:
-            import winloop  # type:ignore
-            return winloop.new_event_loop()
-        
+    # NOTE: I am working to pytest-asyncio in the future to workaround needing event-loop-policies
 
+    if sys.version_info >= (3, 14):
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            from asyncio import DefaultEventLoopPolicy
+    else:
+        from asyncio import DefaultEventLoopPolicy
 
-@pytest_asyncio.fixture(loop_scope="module")
-async def current_loop():
-    return asyncio.get_running_loop()
+    @pytest.fixture(
+        scope="session",
+        params=(
+            DefaultEventLoopPolicy(),
+            uvloop.EventLoopPolicy(),
+        ),
+        ids=str
+    )
+    def event_loop_policy(request:pytest.FixtureRequest) -> asyncio.AbstractEventLoopPolicy:
+        return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,24 +11,19 @@ uvloop = pytest.importorskip("winloop" if sys.platform == "win32" else "uvloop")
 if platform.python_implementation() != "PyPy":
     # NOTE: I am working to pytest-asyncio in the future to workaround needing event-loop-policies
 
-    if sys.version_info >= (3, 14):
-        import warnings
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore", DeprecationWarning)
-            from asyncio import DefaultEventLoopPolicy
-    else:
+    if sys.version_info <= (3, 14):
         from asyncio import DefaultEventLoopPolicy
 
-    @pytest.fixture(
-        scope="session",
-        params=(
-            DefaultEventLoopPolicy(),
-            uvloop.EventLoopPolicy(),
-        ),
-        ids=str,
-    )
-    def event_loop_policy(
-        request: pytest.FixtureRequest,
-    ) -> asyncio.AbstractEventLoopPolicy:
-        return request.param
+        @pytest.fixture(
+            scope="session",
+            params=(
+                DefaultEventLoopPolicy(),
+                uvloop.EventLoopPolicy(),
+            ),
+            ids=str,
+        )
+        def event_loop_policy(
+            request: pytest.FixtureRequest,
+        ) -> asyncio.AbstractEventLoopPolicy:
+            return request.param
+    

--- a/tests/test_eventlists.py
+++ b/tests/test_eventlists.py
@@ -1,18 +1,20 @@
-import asyncio
-import sys
-from dataclasses import dataclass
 import platform
+from dataclasses import dataclass
 
 import pytest
-import pytest_asyncio
-
-from aiocallback.events import (EventList, contextevent, event, subclassevent,
-                                subcontextevent)
-
 from propcache import under_cached_property
+
+from aiocallback.events import (
+    EventList,
+    contextevent,
+    event,
+    subclassevent,
+    subcontextevent,
+)
 
 try:
     import attrs
+
     ATTRS_NOT_FOUND = False
 except ModuleNotFoundError:
     ATTRS_NOT_FOUND = True
@@ -20,10 +22,11 @@ except ModuleNotFoundError:
 
 try:
     # As much as you should try migrating to using msgspec
-    # until pydantic decides to migrate it's 
+    # until pydantic decides to migrate it's
     # metaclass BaseModel to C / Cython / Rust
     # I shall do my fair share of trying to support it.
     import pydantic
+
     PYDANTIC_NOT_FOUND = False
 except ModuleNotFoundError:
     PYDANTIC_NOT_FOUND = True
@@ -33,6 +36,7 @@ try:
     # XXX: PyPy does not do well with msgspec apparently...
     if platform.python_implementation() != "PyPy":
         import msgspec
+
         MSGSPEC_NOT_FOUND = False
     else:
         MSGSPEC_NOT_FOUND = True
@@ -40,40 +44,32 @@ except ModuleNotFoundError:
     MSGSPEC_NOT_FOUND = True
 
 
-attrs_test = pytest.mark.skipif(
-    ATTRS_NOT_FOUND, reason="Attrs Not Found!"
-)
+attrs_test = pytest.mark.skipif(ATTRS_NOT_FOUND, reason="Attrs Not Found!")
 
-pydantic_test = pytest.mark.skipif(
-    PYDANTIC_NOT_FOUND, reason="Pydantic Not Found!"
-)
+pydantic_test = pytest.mark.skipif(PYDANTIC_NOT_FOUND, reason="Pydantic Not Found!")
 
-msgspec_test = pytest.mark.skipif(
-    MSGSPEC_NOT_FOUND, reason="Msgspec Not Found!"
-)
-
+msgspec_test = pytest.mark.skipif(MSGSPEC_NOT_FOUND, reason="Msgspec Not Found!")
 
 
 @pytest.mark.asyncio
 async def test_eventlist_freezing():
-    
     class MyEvents(EventList):
         @event
-        async def my_event_1(self):
+        async def my_event_1(self) -> None:
             pass
-        
+
         @contextevent
-        async def my_event_2(self):
+        async def my_event_2(self) -> None:
             pass
 
         @subclassevent
-        async def my_event_3(self):
+        async def my_event_3(self) -> None:
             pass
 
         @subcontextevent
-        async def my_event_4(self):
+        async def my_event_4(self) -> None:
             pass
-    
+
     my_events = MyEvents()
     my_events.freeze()
     for e in my_events.events:
@@ -84,71 +80,71 @@ async def test_eventlist_freezing():
 # - Lazy setting
 # - Lazy Initialization
 #
-# With dataclass support added and now with attrs support, 
+# With dataclass support added and now with attrs support,
 # you can get as lazy as you want.
 
+
 @pytest.mark.asyncio
-async def test_dataclass_eventlist_support():
+async def test_dataclass_eventlist_support() -> None:
     @dataclass
     class MyEvents(EventList):
         x: int = 0
         y: int = 0
+
         @event
-        async def my_event_1(self):
+        async def my_event_1(self) -> None:
             pass
-        
+
         @contextevent
-        async def my_event_2(self):
+        async def my_event_2(self) -> None:
             pass
 
         @subclassevent
-        async def my_event_3(self):
+        async def my_event_3(self) -> None:
             pass
 
         @subcontextevent
-        async def my_event_4(self):
+        async def my_event_4(self) -> None:
             pass
-    
+
     e = MyEvents(1, 2)
     assert e.x == 1
     assert e.y == 2
-    
+
     for i in range(1, 4):
         assert f"my_event_{i}" in e.events, f"my_event_{i} wasn't registered"
-        
+
     e.freeze()
 
     # Test Freezing
     for attr in e.events:
-        assert e.__getattribute__(attr).frozen, f'{attr} did not freeze'
-
-
+        assert e.__getattribute__(attr).frozen, f"{attr} did not freeze"
 
 
 @attrs_test
 @pytest.mark.asyncio
-async def test_attrs_eventlist_support():
-   
+async def test_attrs_eventlist_support() -> None:
     @attrs.define
     class MyEvents(EventList):
         x: int = 0
         y: int = 0
+
         @event
-        async def my_event_1(self):
+        async def my_event_1(self) -> None:
             pass
-        
+
         @contextevent
-        async def my_event_2(self):
+        async def my_event_2(self) -> None:
             pass
 
         @subclassevent
-        async def my_event_3(self):
+        async def my_event_3(self) -> None:
             pass
 
         @subcontextevent
-        async def my_event_4(self):
+        async def my_event_4(self) -> None:
             pass
-    
+
     e = MyEvents(1, 2)
     assert e.x == 1
     assert e.y == 2
@@ -159,68 +155,65 @@ async def test_attrs_eventlist_support():
 
     # Test Freezing
     for attr in e.events:
-        assert e.__getattribute__(attr).frozen, f'{attr} did not freeze'
-
-
+        assert e.__getattribute__(attr).frozen, f"{attr} did not freeze"
 
 
 @pydantic_test
 @pytest.mark.asyncio
-async def test_pydantic_eventlist_support():
-   
+async def test_pydantic_eventlist_support() -> None:
     @pydantic.dataclasses.dataclass
     class MyEvents(EventList):
         x: int = 0
         y: int = 0
+
         @event
-        async def my_event_1(self):
+        async def my_event_1(self) -> None:
             pass
-        
+
         @contextevent
-        async def my_event_2(self):
+        async def my_event_2(self) -> None:
             pass
 
         @subclassevent
-        async def my_event_3(self):
+        async def my_event_3(self) -> None:
             pass
 
         @subcontextevent
-        async def my_event_4(self):
+        async def my_event_4(self) -> None:
             pass
-    
+
     e = MyEvents(1, 2)
     assert e.x == 1
     assert e.y == 2
     # Test registration
     for i in range(1, 4):
         assert f"my_event_{i}" in e.events, f"my_event_{i} wasn't registered"
-        
+
     e.freeze()
 
     # Test Freezing
     for attr in e.events:
-        assert e.__getattribute__(attr).frozen, f'{attr} did not freeze'
-
+        assert e.__getattribute__(attr).frozen, f"{attr} did not freeze"
 
 
 @msgspec_test
 @pytest.mark.asyncio
-async def test_msgspec_struct_support():
-    # I don't expect msgspec to support 
-    # Eventlists yet since it has strict rules about what goes into 
+async def test_msgspec_struct_support() -> None:
+    # I don't expect msgspec to support
+    # Eventlists yet since it has strict rules about what goes into
     # it and out of it.
 
-    # Until Msgspec's StructMeta Class Object is Publically Exposed 
+    # Until Msgspec's StructMeta Class Object is Publically Exposed
     # I don't Expcet us supporting it anytime soon...
 
     # However we can test if at least one event will freeze
 
     class MyEvents(msgspec.Struct, dict=False):
-        x:int = 0
-        y:int = 0
+        x: int = 0
+        y: int = 0
 
         @event
-        async def my_event_1(self):
+        async def my_event_1(self) -> None:
             pass
 
     e = MyEvents(1, 2)
@@ -231,25 +224,23 @@ async def test_msgspec_struct_support():
     assert e.my_event_1.frozen, "msgspec.Struct did not freeze the event"
 
 
-    
 @pytest.mark.asyncio
-async def test_eventlist_propercache_under_cached_property_support():
-    
+async def test_eventlist_propercache_under_cached_property_support() -> None:
     class Events(EventList):
         @event
-        async def my_event_1(self):
+        async def my_event_1(self) -> None:
             pass
-        
+
         @under_cached_property
         def value(self) -> int:
             return 2
-    
+
     e = Events()
     assert e.value == 2
 
-@pytest.mark.asyncio
-async def test_eventlist_propercache_under_cached_property_immutable():
 
+@pytest.mark.asyncio
+async def test_eventlist_propercache_under_cached_property_immutable() -> None:
     class Events(EventList):
         @under_cached_property
         def value(self) -> int:
@@ -261,7 +252,8 @@ async def test_eventlist_propercache_under_cached_property_immutable():
     with pytest.raises(AttributeError):
         e.value = 3
 
-# XXX: Currently not supported and fails, 
+
+# XXX: Currently not supported and fails,
 # maybe in a future update this can get supported
 
 # @pytest.mark.asyncio

--- a/tests/test_eventlists.py
+++ b/tests/test_eventlists.py
@@ -9,6 +9,8 @@ import pytest_asyncio
 from aiocallback.events import (EventList, contextevent, event, subclassevent,
                                 subcontextevent)
 
+from propcache import under_cached_property
+
 try:
     import attrs
     ATTRS_NOT_FOUND = False
@@ -230,4 +232,45 @@ async def test_msgspec_struct_support():
 
 
     
+@pytest.mark.asyncio
+async def test_eventlist_propercache_under_cached_property_support():
+    
+    class Events(EventList):
+        @event
+        async def my_event_1(self):
+            pass
+        
+        @under_cached_property
+        def value(self) -> int:
+            return 2
+    
+    e = Events()
+    assert e.value == 2
 
+@pytest.mark.asyncio
+async def test_eventlist_propercache_under_cached_property_immutable():
+
+    class Events(EventList):
+        @under_cached_property
+        def value(self) -> int:
+            return 2
+
+    e = Events()
+    assert e.value == 2
+
+    with pytest.raises(AttributeError):
+        e.value = 3
+
+# XXX: Currently not supported and fails, 
+# maybe in a future update this can get supported
+
+# @pytest.mark.asyncio
+# async def test_eventlist_allow_slots():
+#     class Events(EventList):
+#         __slots__ = ("_cache", "_events")
+#         @under_cached_property
+#         def value(self) -> int:
+#             return 2
+
+#     e = Events()
+#     assert e.value == 2

--- a/tests/test_eventwrapper.py
+++ b/tests/test_eventwrapper.py
@@ -1,35 +1,39 @@
-import asyncio
 import random
-import sys
 
 import pytest
-import pytest_asyncio
 
-from aiocallback.events import (EventWrapper, contextevent, event,
-                                subclassevent, subcontextevent)
-
-
+from aiocallback.events import (
+    EventWrapper,
+    contextevent,
+    event,
+    subclassevent,
+    subcontextevent,
+)
 
 
 def compute_result():
     """Simple addition function test"""
-    a, b = random.choices([1, 2, 3,4, 5, 6, 7, 8, 9, 0], k=2)
+    a, b = random.choices([1, 2, 3, 4, 5, 6, 7, 8, 9, 0], k=2)
     result = a + b
     return result, a, b
+
 
 def random_value():
     return random.randint(0, 5000)
 
+
 @pytest.mark.asyncio
 async def test_eventwrapper():
     add_event = EventWrapper()
-    
-    result , a , b = compute_result()
+
+    result, a, b = compute_result()
 
     @add_event
-    async def on_add(a:int, b:int):
+    async def on_add(a: int, b: int):
         nonlocal result
-        assert a + b == result, f"on_add did not send {a}+{b} correctly and got {result}"
+        assert a + b == result, (
+            f"on_add did not send {a}+{b} correctly and got {result}"
+        )
 
     add_event.freeze()
     await add_event.send(a, b)
@@ -37,28 +41,29 @@ async def test_eventwrapper():
 
 @pytest.mark.asyncio
 async def test_eventwrapper_member_descriptor():
-    result , a , b = compute_result()
+    result, a, b = compute_result()
 
     class TestEvent:
         @event
-        async def on_add(self, a:int, b:int) -> None: # type: ignore
+        async def on_add(self, a: int, b: int) -> None:  # type: ignore
             raise RuntimeError("on_add disallows internal calling")
-        
-    
+
     test_event = TestEvent()
-    
-    async def run_test(a:int, b:int):
+
+    async def run_test(a: int, b: int):
         nonlocal result
-        assert a + b == result, f"on_add event did not send {a}+{b} correctly and got {result}"
+        assert a + b == result, (
+            f"on_add event did not send {a}+{b} correctly and got {result}"
+        )
 
     @test_event.on_add
-    async def generic_on_add(a:int, b:int):
+    async def generic_on_add(a: int, b: int):
         await run_test(a, b)
 
     # Test appending an event
-    async def on_add_append(a:int, b:int):
+    async def on_add_append(a: int, b: int):
         await run_test(a, b)
-    
+
     test_event.on_add.append(on_add_append)
 
     assert generic_on_add in test_event.on_add, "generic_on_add was not added"
@@ -68,28 +73,34 @@ async def test_eventwrapper_member_descriptor():
     assert test_event.on_add.frozen, "on_add is not frozen"
     await test_event.on_add.send(a, b)
 
+
 @pytest.mark.asyncio
 async def test_eventwrapper_subclass_memeber_descriptor():
-    
     class TestSubclassEvent:
         def __init__(self):
             self.event_called = False
-        
+
         @subclassevent
-        async def subcls_event(self, value:int):
-            assert hasattr(self, "event_called"), "TestSubclassEvent Was initalized the wrong way."
+        async def subcls_event(self, value: int):
+            assert hasattr(self, "event_called"), (
+                "TestSubclassEvent Was initalized the wrong way."
+            )
             self.event_called = True
 
     test_sub_event = TestSubclassEvent()
 
-    assert not test_sub_event.event_called, "event_called wasn't called yet but was flagged as true"
+    assert not test_sub_event.event_called, (
+        "event_called wasn't called yet but was flagged as true"
+    )
 
     SHOULDVE_CALLED_FOR = random_value()
 
     @test_sub_event.subcls_event
-    async def on_subclass_called(value:int):
+    async def on_subclass_called(value: int):
         nonlocal SHOULDVE_CALLED_FOR
-        assert SHOULDVE_CALLED_FOR == value, "SHOULDVE_CALLED_FOR WAS INCORRECT Value:{!r}".format(value)
+        assert SHOULDVE_CALLED_FOR == value, (
+            "SHOULDVE_CALLED_FOR WAS INCORRECT Value:{!r}".format(value)
+        )
 
     assert on_subclass_called in test_sub_event.subcls_event, "callback wasn't given"
 
@@ -99,34 +110,44 @@ async def test_eventwrapper_subclass_memeber_descriptor():
 
     assert test_sub_event.event_called, "subcls_event Was not Called"
 
+
 @pytest.mark.asyncio
 async def test_eventwrapper_contextevent():
     class TestContextEvent:
         def __init__(self):
             self.event_called = False
-        
+
         @contextevent
-        async def subcls_event(self, _:int) -> None: # type: ignore
+        async def subcls_event(self, _: int) -> None:  # type: ignore
             raise RuntimeError("class's inner event wasn't ignored")
 
-    
     test_sub_event = TestContextEvent()
 
-    assert not test_sub_event.event_called, "event_called wasn't called yet but was flagged as true"
+    assert not test_sub_event.event_called, (
+        "event_called wasn't called yet but was flagged as true"
+    )
 
     SHOULDVE_CALLED_FOR = random_value()
 
     @test_sub_event.subcls_event
-    async def on_subclass_called(event:TestContextEvent, value:int):
-        assert hasattr(event, "event_called"), "instanced of the event should've been passed"
+    async def on_subclass_called(event: TestContextEvent, value: int):
+        assert hasattr(event, "event_called"), (
+            "instanced of the event should've been passed"
+        )
 
         nonlocal SHOULDVE_CALLED_FOR
-        assert SHOULDVE_CALLED_FOR == value, "SHOULDVE_CALLED_FOR WAS INCORRECT, \"Value Passed\":{!r}".format(value)
+        assert SHOULDVE_CALLED_FOR == value, (
+            'SHOULDVE_CALLED_FOR WAS INCORRECT, "Value Passed":{!r}'.format(value)
+        )
 
-    assert on_subclass_called in test_sub_event.subcls_event, "subclassevent member descriptor had an attribute problem"
+    assert on_subclass_called in test_sub_event.subcls_event, (
+        "subclassevent member descriptor had an attribute problem"
+    )
     test_sub_event.subcls_event.freeze()
     await test_sub_event.subcls_event.send(SHOULDVE_CALLED_FOR)
-    assert not test_sub_event.event_called, "Event Shouldn't have been set to begin with"
+    assert not test_sub_event.event_called, (
+        "Event Shouldn't have been set to begin with"
+    )
 
 
 @pytest.mark.asyncio
@@ -134,35 +155,37 @@ async def test_eventwrapper_subcontextevent():
     class TestSubContextEvent:
         def __init__(self):
             self.event_called = False
-        
+
         @subcontextevent
-        async def subcls_event(self, _:int) -> None: # type: ignore
-            assert hasattr(self, "event_called"), "TestSubContextEvent Was initalized the wrong way."
+        async def subcls_event(self, _: int) -> None:  # type: ignore
+            assert hasattr(self, "event_called"), (
+                "TestSubContextEvent Was initalized the wrong way."
+            )
             self.event_called = True
 
     test_sub_event = TestSubContextEvent()
 
-    assert not test_sub_event.event_called, "event_called wasn't called yet but was flagged as true"
+    assert not test_sub_event.event_called, (
+        "event_called wasn't called yet but was flagged as true"
+    )
 
     SHOULDVE_CALLED_FOR = random_value()
 
     @test_sub_event.subcls_event
-    async def on_subclass_called(event:TestSubContextEvent, value:int):
-        assert hasattr(event, "event_called"), "instance of this event should've been passed"
+    async def on_subclass_called(event: TestSubContextEvent, value: int):
+        assert hasattr(event, "event_called"), (
+            "instance of this event should've been passed"
+        )
 
         nonlocal SHOULDVE_CALLED_FOR
-        assert SHOULDVE_CALLED_FOR == value, "SHOULDVE_CALLED_FOR WAS INCORRECT, \"Value Passed\":{!r}".format(value)
+        assert SHOULDVE_CALLED_FOR == value, (
+            'SHOULDVE_CALLED_FOR WAS INCORRECT, "Value Passed":{!r}'.format(value)
+        )
 
-    assert on_subclass_called in test_sub_event.subcls_event, "subclassevent member descriptor had an attribute problem"
+    assert on_subclass_called in test_sub_event.subcls_event, (
+        "subclassevent member descriptor had an attribute problem"
+    )
     test_sub_event.subcls_event.freeze()
     await test_sub_event.subcls_event.send(SHOULDVE_CALLED_FOR)
 
     assert test_sub_event.event_called, "Inner function was not called"
-
-
-
-
-
-
-
-


### PR DESCRIPTION
This is my planned features for aiocallback which includes
- `under_cached_property` support for users who want to use it
- Internal refactoring 
- Trusted Publisher for aiocallback (Already took care of this on pypi's end. This will go into affect next update
- Deprecated Materials have been removed as I have warned it's removal in __0.1.7__ 
- `deprecated-params` library has been dropped use of unless we want to return to using it, it's what I invented it for and it's served it's purpose well when you want to drop or reuse in the future.
- Better Documentation for when we decide to give it a new dedicated readthedocs.io page in a future update (Maybe __0.1.9__) I have plans for __0.1.8__ to include a new single-dispatch version of the EventWrapper that removes events after first use I might make it so that it's always dynamic so that it doesn't need freezing incase some functions want to be reused. 
- This library still serves the purpose of being beginner friendly for newbies who are looking for something similar to aiosignal that provides an easier interface to work with.
